### PR TITLE
feat: Add reload method to ConfigManager

### DIFF
--- a/platform-paper/src/main/kotlin/dev/m1sk9/lunaticChat/paper/config/ConfigManager.kt
+++ b/platform-paper/src/main/kotlin/dev/m1sk9/lunaticChat/paper/config/ConfigManager.kt
@@ -54,4 +54,6 @@ object ConfigManager {
         lunaticChatConfiguration = loadedConfig
         return loadedConfig
     }
+
+    fun reload(configFile: FileConfiguration): LunaticChatConfiguration = loadConfiguration(configFile)
 }


### PR DESCRIPTION
Add a reload method to ConfigManager that allows reloading the configuration from a FileConfiguration object. This method internally calls loadConfiguration to refresh the cached configuration.