### PR TITLE
fix(docs): add custom domain to wrangler config

### DIFF
--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -8,6 +8,9 @@
   "assets": {
     "directory": "dist"
   },
+  "routes": [
+    { "pattern": "lc.m1sk9.dev", "custom_domain": true }
+  ],
   "compatibility_flags": [
     "nodejs_compat"
   ]


### PR DESCRIPTION
Explicitly declare lc.m1sk9.dev as a custom domain in wrangler.jsonc to ensure the domain binding is applied on every deploy. Without this, the Worker would intermittently fall back to a "Deploying..." placeholder.