### PR TITLE
chore(release): Paper 26.1.2 support

### DIFF
--- a/.github/workflows/release-paper.yaml
+++ b/.github/workflows/release-paper.yaml
@@ -120,7 +120,7 @@ jobs:
 
           gh release create "$TAG_NAME" \
             "platform-paper/build/libs/$JAR_NAME" \
-            --title "LunaticChat v${VERSION} (Paper/Folia)" \
+            --title "v${VERSION} (Paper/Folia)" \
             --draft \
             --notes-file /tmp/release-notes.md
 

--- a/.github/workflows/release-velocity.yaml
+++ b/.github/workflows/release-velocity.yaml
@@ -121,7 +121,7 @@ jobs:
 
           gh release create "$TAG_NAME" \
             "platform-velocity/build/libs/$JAR_NAME" \
-            --title "LunaticChat v${VERSION} (Velocity)" \
+            --title "v${VERSION} (Velocity)" \
             --draft \
             --notes-file /tmp/release-notes.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v1
 
+### v1.2.0
+
+- Paper 26.1.2 (Minecraft 26.1.2) is now supported.
+  - We have also added code support for Paper 26.1.1 (Minecraft 26.1.1). However, since this is not the latest version, we cannot guarantee its functionality (LunaticChat only supports the latest version).
+
 ### v1.1.0
 
 - Add an alias for a subcommand.

--- a/docker/folia/compose.yaml
+++ b/docker/folia/compose.yaml
@@ -12,7 +12,7 @@ services:
     environment:
       EULA: "TRUE"
       TYPE: "FOLIA"
-      VERSION: "26.1.1"
+      VERSION: "26.1.2"
       MEMORY: "2G"
 
       # デバッグ用高速化設定

--- a/docker/paper/compose.yaml
+++ b/docker/paper/compose.yaml
@@ -12,7 +12,7 @@ services:
     environment:
       EULA: "TRUE"
       TYPE: "PAPER"
-      VERSION: "26.1.1"
+      VERSION: "26.1.2"
       MEMORY: "1G"
 
       # デバッグ用高速化設定

--- a/docker/velocity/compose.yaml
+++ b/docker/velocity/compose.yaml
@@ -40,7 +40,7 @@ services:
     environment:
       EULA: "TRUE"
       TYPE: "PAPER"
-      VERSION: "26.1.1"
+      VERSION: "26.1.2"
       MEMORY: "1G"
 
       # デバッグ用高速化設定
@@ -87,7 +87,7 @@ services:
     environment:
       EULA: "TRUE"
       TYPE: "PAPER"
-      VERSION: "26.1.1"
+      VERSION: "26.1.2"
       MEMORY: "1G"
 
       # デバッグ用高速化設定

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 
 # Platform versions (can be released independently)
-paperVersion=1.1.0
+paperVersion=1.2.0
 velocityVersion=1.0.0


### PR DESCRIPTION
- Bump paperVersion to 1.2.0
- Update docker compose files to Paper/Folia 26.1.2
- Add v1.2.0 entry to CHANGELOG
- Drop "LunaticChat" prefix from release titles