### PR TITLE
chore(release): prepare paper v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v1
 
+### v1.2.1
+
+- Dependency updates only. There are no functional changes to the plugin.
+  - Updated Paper API to 26.1.2 (build.67).
+  - Updated libraries: kotlinx-coroutines 1.11.0, Ktor 3.5.0, JUnit 6.1.0, and MockK 1.14.11.
+  - Updated Gradle to 9.5.1.
+  - Updated the Shadow plugin to 9.4.2.
+
 ### v1.2.0
 
 - Paper 26.1.2 (Minecraft 26.1.2) is now supported.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.parallel=true
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 
 # Platform versions (can be released independently)
-paperVersion=1.2.0
+paperVersion=1.2.1
 velocityVersion=1.0.0


### PR DESCRIPTION
## Summary

Dependency-only release for Paper v1.2.1. No functional changes.

- Bump `paperVersion` to `1.2.1` in `gradle.properties`
- Add v1.2.1 entry to `CHANGELOG.md` summarizing dependency updates merged since v1.2.0:
  - Paper API 26.1.2 build.67
  - kotlinx-coroutines 1.11.0, Ktor 3.5.0, JUnit 6.1.0, MockK 1.14.11
  - Gradle 9.5.1
  - Shadow plugin 9.4.2

## Test plan

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test`
- [x] `./gradlew :platform-paper:shadowJar`
- [ ] After merge, tag `paper/v1.2.1` and push to trigger `release-paper.yaml`

Generated with Claude Code