### PR TITLE
ci: let a newer Pages deploy supersede a stuck one

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,12 +81,15 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build_dokka
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       pages: write
       id-token: write
+    # A superseded docs deploy is worth discarding: keeping it (cancel-in-progress: false)
+    # let one stuck job hold the "pages" group and stall every later main run behind it.
     concurrency:
       group: "pages"
-      cancel-in-progress: false
+      cancel-in-progress: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## What

`deploy_dokka` の concurrency を `cancel-in-progress: true` に変更し，`timeout-minutes: 10` を追加しました．

## Why

2026-08-07 05:29 UTC に開始した `deploy_dokka` (run [31150675769](https://github.com/m1sk9/LunaticChat/actions/runs/31150675769)) が `waiting` のまま 23 日間停止し，main の CI を止めていました．

止まった状態の実体は runner 待ちの `queued` ではなく，`environment: github-pages` の deployment protection rule 待ちである `waiting` でした（check-run API 上 `status: waiting` / `runner_id: null` / `steps: []`）．対応する deployment レコード `5789315729` にはステータスが 1 件も記録されておらず，正常系なら 1 秒で付く `waiting` すら無い状態で，ゲートの評価自体が始まっていませんでした．

リポジトリ設定側に待ち続ける理由はありません．`github-pages` 環境の protection rule は `main` を許可する branch policy 1 件のみで，承認者ルールも wait timer もなく，同一設定で 8/5 は 1 秒でゲートを通過し，詰まりを手動解除した 8/30 も正常に通っています．GitHub 側でゲート評価が宙に浮いたものと見られ，外部から追える範囲では一次原因はここまでです．

問題は，それが 23 日間放置される構造がこちら側にあったことです．

- `waiting` 状態の job は GitHub の 24 時間キュータイムアウトの対象外（あれは runner 割り当て待ちに効く）
- `cancel-in-progress: false` のため，詰まった job が `pages` グループを掴んだまま離さない
- concurrency の pending 枠は 1 つなので，新しい main push が来ると**詰まっている側ではなく待たされている側**がキャンセルされる

結果，main push のたびに古い job が生き残り新しい run が死ぬ，を繰り返していました（8/7 10:00 の run の `deploy_dokka` は，次の main push が届いた 14:10:41 にキャンセルされている）．

`cancel-in-progress: true` にすれば次の main push が古い方を追い越すため，同じことが起きても数時間で自然解消します．docs サイトの deploy なので，追い越された deploy を捨てても実害はありません（新しい run がより新しい docs を publish する）．

## Note

`timeout-minutes: 10` は今回のケースには効きません．`timeout-minutes` は job が実行を開始してから計測が始まるため `waiting` には作用しないためで，実行中に hang した場合の別枠の保険として入れています．`waiting` を YAML 側からタイムアウトさせる手段は無く，実質 `cancel-in-progress: true` が唯一の防御です．

## 詰まっていた run について

run [31150675769](https://github.com/m1sk9/LunaticChat/actions/runs/31150675769) は調査時に手動でキャンセル済みです．解除後，待たされていた [33293521147](https://github.com/m1sk9/LunaticChat/actions/runs/33293521147) の `deploy_dokka` が即座に走って success し，Pages への deploy も 23 日ぶりに通っています．

Generated by Claude Code